### PR TITLE
Use nova-compute charm from the openstack-charmers-next repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ or `reboot`.
 
 ## Supported charms
 
-* nova-compute (WIP) (Usable with [this nova-compute charm](https://jaas.ai/u/martin-kalcok/nova-compute/0))
+* nova-compute (Usable with the next stable release of the charm. Currently available as a [pre-release](https://jaas.ai/u/openstack-charmers-next/nova-compute/562))
 * ceph-osd (WIP)
 * neutron-gateway (WIP)
 

--- a/tests/functional/tests/bundles/nova-compute.yaml
+++ b/tests/functional/tests/bundles/nova-compute.yaml
@@ -93,7 +93,7 @@ applications:
     options:
       openstack-origin: cloud:bionic-ussuri
   nova-compute:
-    charm: cs:~martin-kalcok/nova-compute-0
+    charm: cs:~openstack-charmers-next/nova-compute-562
     num_units: 2
     constraints: mem=4G cores=4
     options:


### PR DESCRIPTION
Since all the required changes are already merged into the next release of `nova-compute` charm we can use `openstack-charmers-next` namepsace instead of my personal.

(I tested functional tests just to be sure and they passed.)