### PR TITLE
catch falling action

### DIFF
--- a/juju_verify/exceptions.py
+++ b/juju_verify/exceptions.py
@@ -16,6 +16,11 @@
 # this program. If not, see https://www.gnu.org/licenses/.
 
 """Collection of juju verification exceptions."""
+import os
+from typing import Optional, Dict, Any
+
+from juju.errors import JujuError
+from juju.unit import Unit
 
 
 class VerificationError(Exception):
@@ -24,3 +29,17 @@ class VerificationError(Exception):
 
 class CharmException(Exception):
     """Exception related to the charm or the unit that runs it."""
+
+
+class ActionFailed(Exception):
+    """Exception related to failing action run on the unit."""
+
+    def __init__(self, error: JujuError, unit: Unit, action: str,
+                 params: Optional[Dict[str, Any]] = None):
+        """Initialize ActionFailed error message."""
+        params = params or {}
+        params_str = " ".join(f"{name}={value}" for name, value in params.items())
+        juju_error_message = os.linesep.join(f"  {err}" for err in error.errors)
+        self.message = f"{unit.entity_id}: action `{action}{params_str}` failed " \
+                       f"with errors:{os.linesep}{juju_error_message}"
+        super().__init__(self.message)

--- a/juju_verify/utils/unit.py
+++ b/juju_verify/utils/unit.py
@@ -16,11 +16,13 @@
 # this program. If not, see https://www.gnu.org/licenses/.
 """Helper function to manage Juju unit."""
 import asyncio
+import logging
 import os
 import re
 from typing import List, Dict, Any, Optional
 
 from juju.action import Action
+from juju.errors import JujuError
 from juju.model import Model
 from juju.unit import Unit
 
@@ -28,6 +30,8 @@ from juju_verify.exceptions import VerificationError, CharmException
 from juju_verify.utils.action import cache
 
 CHARM_URL_PATTERN = re.compile(r'^(.*):(.*/)?(?P<charm>.*)(-\d+)$')
+
+logger = logging.getLogger(__name__)
 
 
 def get_cache_key(unit: Unit, action: str, **params: Any) -> int:
@@ -44,8 +48,15 @@ async def run_action(unit: Unit, action: str, use_cache: bool = True,
     key = get_cache_key(unit, action, **params)
 
     if key not in cache or not use_cache:
-        _action = await unit.run_action(action, **params)
-        result = await _action.wait()  # wait for result
+        try:
+            _action = await unit.run_action(action, **params)
+            result = await _action.wait()  # wait for result
+        except JujuError as error:
+            params_str = " ".join(f"{name}={value}" for name, value in params.items())
+            error_message = os.linesep.join(f"  {err}" for err in error.errors)
+            logger.error("action `%s %s` failed with errors: %s%s",
+                         action, params_str, os.linesep, error_message)
+            raise CharmException(f"action `{action}` failed") from error
         cache[key] = result  # save result to cache
         return result
 

--- a/juju_verify/verifiers/ceph.py
+++ b/juju_verify/verifiers/ceph.py
@@ -30,7 +30,7 @@ from juju_verify.utils.unit import (
     get_first_active_unit,
     get_applications_names
 )
-from juju_verify.verifiers.base import BaseVerifier
+from juju_verify.verifiers.base import BaseVerifier, catch_check_failure
 from juju_verify.verifiers.result import aggregate_results, Result, Severity
 from juju_verify.exceptions import CharmException
 
@@ -91,6 +91,7 @@ class CephCommon(BaseVerifier):  # pylint: disable=W0223
     """Parent class for CephMon and CephOsd verifier."""
 
     @classmethod
+    @catch_check_failure
     def check_cluster_health(cls, *units: Unit) -> Result:
         """Check Ceph cluster health for specific units.
 
@@ -255,11 +256,13 @@ class CephOsd(CephCommon):
 
         return availability_zones
 
+    @catch_check_failure
     def check_ceph_cluster_health(self) -> Result:
         """Check Ceph cluster health for unique ceph-mon units from ceph_mon_app_map."""
         unique_ceph_mon_units = set(self.ceph_mon_app_map.values())
         return self.check_cluster_health(*unique_ceph_mon_units)
 
+    @catch_check_failure
     def check_replication_number(self) -> Result:
         """Check the minimum number of replications for related applications."""
         result = Result()
@@ -291,6 +294,7 @@ class CephOsd(CephCommon):
                                       'Minimum replica number check passed.')
         return result
 
+    @catch_check_failure
     def check_availability_zone(self) -> Result:
         """Check availability zones resources.
 
@@ -363,6 +367,7 @@ class CephMon(CephCommon):
         """Verify that it's safe to shutdown selected units."""
         return self.verify_reboot()
 
+    @catch_check_failure
     def check_quorum(self) -> Result:
         """Check that the shutdown does not result in <50% mons alive."""
         result = Result()
@@ -389,6 +394,7 @@ class CephMon(CephCommon):
 
         return result
 
+    @catch_check_failure
     def check_version(self) -> Result:
         """Check minimum required version of juju agents on units.
 

--- a/juju_verify/verifiers/nova_compute.py
+++ b/juju_verify/verifiers/nova_compute.py
@@ -20,7 +20,7 @@ import logging
 
 from juju_verify.utils.action import data_from_action
 from juju_verify.utils.unit import run_action_on_unit
-from juju_verify.verifiers.base import BaseVerifier
+from juju_verify.verifiers.base import BaseVerifier, catch_check_failure
 from juju_verify.verifiers.result import aggregate_results, Result, Severity
 
 logger = logging.getLogger()
@@ -31,6 +31,7 @@ class NovaCompute(BaseVerifier):
 
     NAME = 'nova-compute'
 
+    @catch_check_failure
     def check_no_running_vms(self) -> Result:
         """Check that none of the units have VMs running on them."""
         result = Result()
@@ -47,6 +48,7 @@ class NovaCompute(BaseVerifier):
                                                        f'{running_vms} VMs.')
         return result
 
+    @catch_check_failure
     def check_no_empty_az(self) -> Result:
         """Check that removing units wont cause empty availability zone."""
         def is_active(node: dict) -> bool:

--- a/tests/unit/utils/test_unit.py
+++ b/tests/unit/utils/test_unit.py
@@ -25,7 +25,7 @@ from juju.errors import JujuError
 from juju.unit import Unit
 from pytest import raises
 
-from juju_verify.exceptions import VerificationError, CharmException
+from juju_verify.exceptions import VerificationError, CharmException, ActionFailed
 from juju_verify.utils.unit import (
     run_action_on_units,
     verify_charm_unit,
@@ -119,9 +119,9 @@ async def test_run_action_failed():
     unit_1.entity_id.return_value = 1
     unit_1.run_action.side_effect = mock_unit_run_action
 
-    with pytest.raises(CharmException) as error:
+    with pytest.raises(ActionFailed) as error:
         await run_action(unit_1, "test-action", params=dict(format="json"))
-        assert "action `test-action` failed" == str(error.value)
+        assert "[1] action `test-action` failed" == str(error.value)
 
 
 @mock.patch("juju_verify.utils.unit.run_action")

--- a/tests/unit/utils/test_unit.py
+++ b/tests/unit/utils/test_unit.py
@@ -21,6 +21,7 @@ from unittest import mock
 from unittest.mock import MagicMock, call
 
 import pytest
+from juju.errors import JujuError
 from juju.unit import Unit
 from pytest import raises
 
@@ -104,6 +105,23 @@ async def test_run_action():
     unit_1.run_action.assert_has_calls([call("action-3"),
                                         call("action-1", format="text")])
     unit_2.run_action.assert_called_once_with("action-2")
+
+
+@pytest.mark.asyncio
+async def test_run_action_failed():
+    """Test running action failed."""
+
+    async def mock_unit_run_action(action: str, **params: Any) -> Coroutine:
+        """Mock function for Unit.run_action."""
+        raise JujuError("action failed")
+
+    unit_1 = MagicMock()
+    unit_1.entity_id.return_value = 1
+    unit_1.run_action.side_effect = mock_unit_run_action
+
+    with pytest.raises(CharmException) as error:
+        await run_action(unit_1, "test-action", params=dict(format="json"))
+        assert "action `test-action` failed" == str(error.value)
 
 
 @mock.patch("juju_verify.utils.unit.run_action")


### PR DESCRIPTION
This change will give a better output if the action failed.
Now:
```bash
$ juju-verify shutdown --unit ceph-osd-g1/0
WARNING: The function to get the number of free units from 'ceph df' is in WIP and returns only 1. See LP#1921121 for more information.
WARNING: The function to get the number of free units from 'ceph df' is in WIP and returns only 1. See LP#1921121 for more information.
WARNING: The function to get the number of free units from 'ceph df' is in WIP and returns only 1. See LP#1921121 for more information.
Checks:
[WARN] ceph-osd-g1/0 has units running on child machines: ceph-mon-g1/0*
[FAIL] ceph-mon-g1/0: Ceph cluster is unhealthy
[FAIL] check failed with error: ceph-mon-g1/0: action `list-pools format=json` failed with errors:
  validation failed: (root) : additional property "format" is not allowed, given {"format":"json"}
[FAIL] check failed with error: ceph-osd-g2/0: action `get-availability-zone ` failed with errors:
  action "get-availability-zone" not defined on unit "ceph-osd-g2/0"

Overall result: Failed
```
Before:
```bash
$ juju-verify shutdown --unit ceph-osd-g1/0
Verification failed: ['validation failed: (root) : additional property "format" is not allowed, given {"format":"json"}']
```