### PR TITLE
adding try and catch into all checks

### DIFF
--- a/juju_verify/exceptions.py
+++ b/juju_verify/exceptions.py
@@ -16,6 +16,11 @@
 # this program. If not, see https://www.gnu.org/licenses/.
 
 """Collection of juju verification exceptions."""
+import os
+from typing import Optional, Dict, Any
+
+from juju.errors import JujuError
+from juju.unit import Unit
 
 
 class VerificationError(Exception):
@@ -24,3 +29,17 @@ class VerificationError(Exception):
 
 class CharmException(Exception):
     """Exception related to the charm or the unit that runs it."""
+
+
+class ActionFailed(Exception):
+    """Exception related to failing action run on the unit."""
+
+    def __init__(self, error: JujuError, unit: Unit, action: str,
+                 params: Optional[Dict[str, Any]] = None):
+        """Initialize ActionFailed error message."""
+        params = params or {}
+        params_str = " ".join(f"{name}={value}" for name, value in params.items())
+        juju_error_message = os.linesep.join(f"  {err}" for err in error.errors)
+        self.message = f"{unit.entity_id}: action `{action}{params_str}` failed " \
+                       f"with errors:{os.linesep}{juju_error_message}"
+        super().__init__(self.message)

--- a/juju_verify/verifiers/nova_compute.py
+++ b/juju_verify/verifiers/nova_compute.py
@@ -17,7 +17,9 @@
 """nova-compute verification."""
 import json
 import logging
+from json import JSONDecodeError
 
+from juju_verify.exceptions import ActionFailed
 from juju_verify.utils.action import data_from_action
 from juju_verify.utils.unit import run_action_on_unit
 from juju_verify.verifiers.base import BaseVerifier
@@ -35,7 +37,10 @@ class NovaCompute(BaseVerifier):
         """Check that none of the units have VMs running on them."""
         result = Result()
         instance_count_action = 'instance-count'
-        instance_count_results = self.run_action_on_all(instance_count_action)
+        try:
+            instance_count_results = self.run_action_on_all(instance_count_action)
+        except ActionFailed as error:
+            return Result(Severity.FAIL, str(error))
 
         for unit_id, action in instance_count_results.items():
             running_vms = int(data_from_action(action, 'instance-count'))
@@ -52,18 +57,24 @@ class NovaCompute(BaseVerifier):
         def is_active(node: dict) -> bool:
             return node['state'] == 'up' and node['status'] == 'enabled'
 
-        node_name_actions = self.run_action_on_all('node-name')
-        target_nodes = [data_from_action(action, 'node-name')
-                        for _, action in node_name_actions.items()]
+        try:
+            node_name_actions = self.run_action_on_all('node-name')
+            target_nodes = [data_from_action(action, 'node-name')
+                            for _, action in node_name_actions.items()]
 
-        action = run_action_on_unit(self.units[0], 'list-compute-nodes')
-        compute_nodes = json.loads(data_from_action(action, 'compute-nodes'))
+            action = run_action_on_unit(self.units[0], 'list-compute-nodes')
+            compute_nodes = json.loads(data_from_action(action, 'compute-nodes'))
 
-        affected_zones = {node['zone'] for node in compute_nodes
-                          if node['host'] in target_nodes}
-        zones_after_change = {node['zone'] for node in compute_nodes
-                              if node['host'] not in target_nodes and
-                              is_active(node)}
+            affected_zones = {node['zone'] for node in compute_nodes
+                              if node['host'] in target_nodes}
+            zones_after_change = {node['zone'] for node in compute_nodes
+                                  if node['host'] not in target_nodes and
+                                  is_active(node)}
+        except ActionFailed as error:
+            return Result(Severity.FAIL, str(error))
+        except (JSONDecodeError, KeyError):
+            return Result(Severity.FAIL, "parsing information from action "
+                                         "`list-compute-nodes` failed")
 
         empty_zones = affected_zones - zones_after_change
 


### PR DESCRIPTION
This change will give a better output if the action failed.
Now:
```bash
$ juju-verify shutdown --unit ceph-osd-g1/0
WARNING: The function to get the number of free units from 'ceph df' is
in WIP and returns only 1. See LP#1921121 for more information.
WARNING: The function to get the number of free units from 'ceph df' is
in WIP and returns only 1. See LP#1921121 for more information.
WARNING: The function to get the number of free units from 'ceph df' is
in WIP and returns only 1. See LP#1921121 for more information.
Checks:
[WARN] ceph-osd-g1/0 has units running on child machines: ceph-mon-g1/0*
[FAIL] ceph-mon-g1/0: Ceph cluster is unhealthy
[FAIL] check failed with error: ceph-mon-g1/0: action `list-pools
format=json` failed with errors:
  validation failed: (root) : additional property "format" is not
allowed, given {"format":"json"}
[FAIL] check failed with error: ceph-osd-g2/0: action
`get-availability-zone ` failed with errors:
  action "get-availability-zone" not defined on unit "ceph-osd-g2/0"

Overall result: Failed
```
Before:
```bash
$ juju-verify shutdown --unit ceph-osd-g1/0
Verification failed: ['validation failed: (root) : additional property
"format" is not allowed, given {"format":"json"}']
```