### PR TITLE
add __bool__ function to the Result class

### DIFF
--- a/juju_verify/verifiers/ceph.py
+++ b/juju_verify/verifiers/ceph.py
@@ -286,10 +286,7 @@ class CephOsd(CephCommon):
                     f"active."
                 )
 
-        if result.empty:
-            result.add_partial_result(Severity.OK,
-                                      'Minimum replica number check passed.')
-        return result
+        return result or Result(Severity.OK, 'Minimum replica number check passed.')
 
     def check_availability_zone(self) -> Result:
         """Check availability zones resources.
@@ -322,10 +319,7 @@ class CephOsd(CephCommon):
                     f"{free_units:d}, inactive_units={len(inactive_units):d}]"
                 )
 
-        if result.empty:
-            result.add_partial_result(Severity.OK,
-                                      'Availability zone check passed.')
-        return result
+        return result or Result(Severity.OK, 'Availability zone check passed.')
 
     def verify_reboot(self) -> Result:
         """Verify that it's safe to reboot selected ceph-osd units."""
@@ -384,10 +378,7 @@ class CephMon(CephCommon):
                 result.add_partial_result(Severity.FAIL, f"Removing unit {unit_id} will"
                                                          f" lose Ceph mon quorum")
 
-        if result.empty:
-            result.add_partial_result(Severity.OK, 'Ceph-mon quorum check passed.')
-
-        return result
+        return result or Result(Severity.OK, 'Ceph-mon quorum check passed.')
 
     def check_version(self) -> Result:
         """Check minimum required version of juju agents on units.
@@ -409,7 +400,4 @@ class CephMon(CephCommon):
                 raise CharmException(f'Failed to parse juju version from '
                                      f'unit {unit.entity_id}.') from exc
 
-        if result.empty:
-            result.add_partial_result(Severity.OK, 'Minimum juju version check passed.')
-
-        return result
+        return result or Result(Severity.OK, 'Minimum juju version check passed.')

--- a/juju_verify/verifiers/result.py
+++ b/juju_verify/verifiers/result.py
@@ -144,6 +144,10 @@ class Result:
 
         return self.partials == other.partials and self.success == other.success
 
+    def __bool__(self) -> bool:
+        """Return True if result does contain any partial results."""
+        return bool(self.partials)
+
     @property
     def success(self) -> bool:
         """Return overall Result's success.

--- a/tests/unit/verifiers/test_result.py
+++ b/tests/unit/verifiers/test_result.py
@@ -207,6 +207,19 @@ def test_result_eq():
     assert result_original != result_not_matching
 
 
+def test_result_bool():
+    """Test using Result in conditions."""
+    default_result = Result(Severity.OK, "passed")
+    result_1 = Result()
+    result_2 = Result(Severity.OK, "test")
+
+    assert not result_1, "result is not empty"
+    assert (result_1 or default_result) == default_result
+
+    assert result_2, "result is empty"
+    assert (result_2 or default_result) != default_result
+
+
 def test_result_add_partial_result():
     """Test method add_partial_result."""
     result = Result()


### PR DESCRIPTION
This will improve usage if we check if the result is empty.
e.g.
Using:
```python
return result or Result(Severity.OK, 'Minimum juju version check passed.')
```
instead of:
```python
if result.empty:
    result.add_partial_result(Severity.OK, 'Minimum juju version check passed.')

return result
```

fixes: https://bugs.launchpad.net/juju-verify/+bug/1937040