### PR TITLE
Fix neutron-gateway verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Juju-verify requires Juju 2.8.10 or higher.
 * nova-compute (Usable with the next stable release of the charm. Currently available as a [nova-compute-rc])
 * ceph-osd (Usable with the next stable release of the charm. [cs:~openstack-charmers-next/ceph-osd] and [cs:~openstack-charmers-next/ceph-mon])
 * ceph-mon (Usable with the next stable release of the charm. [cs:~openstack-charmers-next/ceph-mon])
-* neutron-gateway (Usable with the custom release of the charm in martin-kalcok namespace. [cs:~openstack-charmers-next/neutron-gateway])
+* neutron-gateway (Usable with the next stable release of the charm. [cs:~openstack-charmers-next/neutron-gateway])
 
 ## Supported checks
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Juju-verify requires Juju 2.8.10 or higher.
 * nova-compute (Usable with the next stable release of the charm. Currently available as a [nova-compute-rc])
 * ceph-osd (Usable with the custom release of the charm in rgildein namespace. [cs:~/rgildein/ceph-osd-0] and [cs:~/rgildein/ceph-mon-3])
 * ceph-mon (Usable with the custom release of the charm in rgildein namespace. [cs:~/rgildein/ceph-mon-3])
-* neutron-gateway (Usable with the custom release of the charm in martin-kalcok namespace. [cs:~/martin-kalcok/neutron-gateway-2])
+* neutron-gateway (Usable with the custom release of the charm in martin-kalcok namespace. [cs:~openstack-charmers-next/neutron-gateway])
 
 ## Supported checks
 
@@ -179,4 +179,4 @@ If you prefer, file a bug or feature request at:
 [nova-compute-rc]: https://jaas.ai/u/openstack-charmers-next/nova-compute/562
 [cs:~/rgildein/ceph-osd-0]: https://jaas.ai/u/rgildein/ceph-osd/0
 [cs:~/rgildein/ceph-mon-3]: https://jaas.ai/u/rgildein/ceph-mon/3
-[cs:~/martin-kalcok/neutron-gateway-2]: https://jaas.ai/u/martin-kalcok/neutron-gateway/2
+[cs:~openstack-charmers-next/neutron-gateway]: https://jaas.ai/u/openstack-charmers-next/neutron-gateway

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -17,7 +17,7 @@ The ``juju-verify`` tool works with this charm revisions:
 * to verify ceph-osd units: **cs:~openstack-charmers-next/ceph-osd** and **cs:~openstack-charmers-next/ceph-mon**
 * to verify ceph-mon units: **cs:~openstack-charmers-next/ceph-mon**
 * to verify nova-compute units: **cs:~openstack-charmers-next/nova-compute-562**
-* to verify neutron-gateway units: **cs:~/martin-kalcok/neutron-gateway-2**
+* to verify neutron-gateway units: **cs:~openstack-charmers-next/neutron-gateway**
 
 
 Installing

--- a/juju_verify/verifiers/neutron_gateway.py
+++ b/juju_verify/verifiers/neutron_gateway.py
@@ -16,7 +16,7 @@
 # this program. If not, see https://www.gnu.org/licenses/.
 """neutron-gateway verification."""
 
-from typing import List, Dict, Any
+from typing import Any, Dict, List
 
 import yaml
 from juju.unit import Unit
@@ -77,13 +77,15 @@ class NeutronGateway(BaseVerifier):
 
             # add host metadata to resource
             for resource_id, info in host_resource_dict.items():
-                resource_list.append({
-                    "id": resource_id,
-                    "host": hostname,
-                    "juju-entity-id": unit.entity_id,
-                    "shutdown": hostname in shutdown_hostname_list,
-                    **info
-                })
+                resource_list.append(
+                    {
+                        "id": resource_id,
+                        "host": hostname,
+                        "juju-entity-id": unit.entity_id,
+                        "shutdown": hostname in shutdown_hostname_list,
+                        **info,
+                    }
+                )
 
         return resource_list
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ packages = find:
 install_requires =
     juju >= 2.8.6
     packaging
+    PyYAML
 
 [options.extras_require]
 dev =
@@ -46,6 +47,7 @@ dev =
     python-openstackclient
     black
     isort
+    types-PyYAML
 # NOTE (rgildein): The zaza and zaza-openstack packages were moved to tox.ini, due to
 #                  the fact that Pypi no longer supports direct dependency.
 #                  https://github.com/pypa/warehouse/issues/7136

--- a/tests/functional/bundles/openstack.yaml
+++ b/tests/functional/bundles/openstack.yaml
@@ -61,7 +61,7 @@ applications:
   neutron-openvswitch:
     charm: cs:~openstack-charmers-next/neutron-openvswitch
   neutron-gateway:
-    charm: cs:~martin-kalcok/neutron-gateway-2
+    charm: cs:~openstack-charmers-next/neutron-gateway
     num_units: 2
     options:
       bridge-mappings: physnet1:br-ex


### PR DESCRIPTION
 - replace `get-status-routers` w/ `show-routers`
 - replace `get-status-dhcp` w/ `show-dhcp-networks`
 - replace `get-status-lb` w/ `show-loadbalancers`
 - using yaml to load actions output instead of json
 - change custom charm to openstack-charmers-next

fixes: [#1944510](https://bugs.launchpad.net/juju-verify/+bug/1944510)