### PR TITLE
Use `build` module to build source and binary distribution

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,8 +49,8 @@ commands =
 
 [testenv:build]
 basepython = python3
-deps =
-commands = python setup.py sdist bdist_wheel
+deps = build
+commands = python -m build
 
 [testenv:build-verify]
 basepython = python3


### PR DESCRIPTION
Directly invoking setup.py is discouraged as per https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

Article suggests using [build](https://pypa-build.readthedocs.io/en/stable/) package to create source and binary distributions.

LP: https://bugs.launchpad.net/juju-verify/+bug/1947969