### PR TITLE
Add support to check units from multiple charms

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,14 @@ $ juju-verify shutdown --units nova-compute/0 nova-compute/1
    Example:
    ```bash
    $ juju-verify shutdown --unit ceph-osd/0
+   ===[ceph-osd/0]===
    Checks:
    [WARN] ceph-osd/0 has units running on child machines: ceph-mon/0*
    [OK] ceph-mon/0: Ceph cluster is healthy
    [OK] Minimum replica number check passed.
    [OK] Availability zone check passed.
 
-   Overall result: OK (Checks passed with warnings)
+   Result: OK (Checks passed with warnings)
    ```
 
 ## How to contribute
@@ -194,13 +195,14 @@ and three ending with a severity OK, but the overall result is OK.
    
 ```bash
 $ juju-verify shutdown --unit ceph-osd/0
+===[ceph-osd/0]===
 Checks:
 [WARN] ceph-osd/0 has units running on child machines: ceph-mon/0*
 [OK] ceph-mon/0: Ceph cluster is healthy
 [OK] Minimum replica number check passed.
 [OK] Availability zone check passed.
 
-Overall result: OK (Checks passed with warnings)
+Result: OK (Checks passed with warnings)
 ```
 
 ## Submit a bug

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -133,22 +133,24 @@ Without ``--stop-on-failure``
 ::
 
   $ juju-verify reboot -u ceph-osd/0 ceph-osd/1
+  ===[ceph-osd/0, ceph-osd/1]===
   Checks:
   [OK] ceph-mon/2: Ceph cluster is healthy
   [FAIL] The minimum number of replicas in 'ceph-osd' is 1 and it's not safe to reboot/shutdown 2 units. 0 units are not active.
   [FAIL] It's not safe to reboot/shutdown units ceph-osd/0, ceph-osd/1 in the availability zone '10-default(-1),1-juju-1234-ceph-0(-2),1-juju-1234-ceph-1(-3),1-juju-1234-ceph-2(-3),0-osd.1(1),0-osd.0(2),0-osd.2(3)'.
 
-  Overall result: Failed
+  Result: Failed
 
 With ``--stop-on-failure``
 ::
 
   $ juju-verify reboot --stop-on-failure -u ceph-osd/0 ceph-osd/1
+  ===[ceph-osd/0, ceph-osd/1]===
   Checks:
   [OK] ceph-mon/2: Ceph cluster is healthy
   [FAIL] The minimum number of replicas in 'ceph-osd' is 1 and it's not safe to reboot/shutdown 2 units. 0 units are not active.
 
-  Overall result: Failed
+  Result: Failed
 
 Usage examples
 ^^^^^^^^^^^^^^
@@ -166,12 +168,13 @@ Let's see what ``juju-verify`` tells us to reboot one ceph-osd unit.
 ::
 
   $ juju-verify reboot -u ceph-osd/0
+  ===[ceph-osd/0]===
   Checks:
   [OK] ceph-mon/2: Ceph cluster is healthy
   [OK] Minimum replica number check passed.
   [OK] Availability zone check passed.
 
-Overall result: OK (All checks passed)
+  Result: OK (All checks passed)
 
 
 However, if we try to reboot two units instead of one, the check should fail.
@@ -181,12 +184,13 @@ two are needed.
 ::
 
   $ juju-verify reboot -u ceph-osd/0 ceph-osd/1
+  ===[ceph-osd/0, ceph-osd/1]===
   Checks:
   [OK] ceph-mon/2: Ceph cluster is healthy
   [FAIL] The minimum number of replicas in 'ceph-osd' is 1 and it's not safe to reboot/shutdown 2 units. 0 units are not active.
   [FAIL] It's not safe to reboot/shutdown units ceph-osd/0, ceph-osd/1 in the availability zone '10-default(-1),1-juju-1234-ceph-0(-2),1-juju-1234-ceph-1(-3),1-juju-1234-ceph-2(-3),0-osd.1(1),0-osd.0(2),0-osd.2(3)'.
 
-  Overall result: Failed
+  Result: Failed
 
 .. _pypi.org: https://pypi.org/project/juju-verify/
 .. _snapcraft: https://snapcraft.io/about

--- a/docs/verifiers/ceph-mon.rst
+++ b/docs/verifiers/ceph-mon.rst
@@ -11,6 +11,7 @@ perform the same set of checks.
 ::
 
   $ juju-verify reboot --unit ceph-mon/0
+  ===[ceph-mon/0]===
   Checks:
   [OK] check_affected_machines check passed
   [OK] check_has_sub_machines check passed
@@ -18,7 +19,7 @@ perform the same set of checks.
   [OK] Ceph-mon quorum check passed.
   [OK] ceph-mon/0: Ceph cluster is healthy
 
-  Overall result: OK (All checks passed)
+  Result: OK (All checks passed)
 
 
 check Juju version

--- a/docs/verifiers/ceph-osd.rst
+++ b/docs/verifiers/ceph-osd.rst
@@ -11,13 +11,14 @@ perform the same set of checks.
 ::
 
   $ juju-verify reboot --unit ceph-osd/0
+  ===[ceph-osd/0]===
   Checks:
   [OK] check_affected_machines check passed
   [OK] ceph-mon/1: Ceph cluster is healthy
   [OK] Minimum replica number check passed.
   [OK] Availability zone check passed.
 
-  Overall result: OK (All checks passed)
+  Result: OK (All checks passed)
 
 
 .. _check Ceph cluster health:

--- a/docs/verifiers/neutron-gateway.rst
+++ b/docs/verifiers/neutron-gateway.rst
@@ -14,6 +14,7 @@ perform the same set of checks.
 ::
 
   $ juju-verify reboot --unit neutron-gateway/0
+  ===[neutron-gateway/0]===
   Checks:
   [OK] check_affected_machines check passed
   [OK] check_has_sub_machines check passed
@@ -23,7 +24,7 @@ perform the same set of checks.
   [OK] Redundancy check passed for: router-list
   [OK] Redundancy check passed for: dhcp-networks
 
-  Overall result: OK (All checks passed)
+  Result: OK (All checks passed)
 
 
 check minimum Juju version

--- a/docs/verifiers/nova-compute.rst
+++ b/docs/verifiers/nova-compute.rst
@@ -10,13 +10,14 @@ perform the same set of checks.
 ::
 
   $ juju-verify reboot --unit nova-compute/0
+  ===[nova-compute/0]===
   Checks:
   [OK] check_affected_machines check passed
   [OK] check_has_sub_machines check passed
   [OK] Unit nova-compute/0 is running 0 VMs.
   [OK] Empty Availability Zone check passed.
 
-  Overall result: OK (All checks passed)
+  Result: OK (All checks passed)
 
 
 check running VMs

--- a/juju_verify/juju_verify.py
+++ b/juju_verify/juju_verify.py
@@ -32,7 +32,7 @@ from juju.unit import Unit
 from juju_verify import logger as juju_verify_logger
 from juju_verify import stream_handler
 from juju_verify.exceptions import CharmException, VerificationError
-from juju_verify.verifiers import BaseVerifier, get_verifier
+from juju_verify.verifiers import BaseVerifier, get_verifiers
 from juju_verify.verifiers.result import set_stop_on_failure
 
 logger = logging.getLogger(__name__)
@@ -199,9 +199,9 @@ def main() -> None:
         fail("juju-verify must target either juju units or juju machines")
 
     try:
-        verifier = get_verifier(units)
-        result = verifier.verify(args.check)
-        logger.info(str(result))
+        for verifier in get_verifiers(units):
+            result = verifier.verify(args.check)
+            logger.info("%s", result)
     except (CharmException, VerificationError, NotImplementedError) as exc:
         fail(str(exc))
 

--- a/juju_verify/verifiers/result.py
+++ b/juju_verify/verifiers/result.py
@@ -132,7 +132,7 @@ class Result:
         output += os.linesep
 
         max_severity = max(partial.severity for partial in self.partials)
-        output += f"Overall result: {self.VERBOSE_MAP.get(max_severity)}"
+        output += f"Result: {self.VERBOSE_MAP.get(max_severity)}{os.linesep}"
         return output
 
     def __add__(self, other: object) -> "Result":

--- a/tests/functional/tests/test_ceph.py
+++ b/tests/functional/tests/test_ceph.py
@@ -9,7 +9,7 @@ from tests.base import BaseTestCase
 
 from juju_verify import juju_verify
 from juju_verify.utils.action import cache_manager
-from juju_verify.verifiers import get_verifier
+from juju_verify.verifiers import get_verifiers
 from juju_verify.verifiers.ceph import CephCommon
 from juju_verify.verifiers.result import Result
 
@@ -63,7 +63,7 @@ class CephOsdTests(BaseTestCase):
         check = "shutdown"
         unit_objects = loop.run(juju_verify.find_units(self.model, units))
         self._wait_to_ceph_cluster()
-        verifier = get_verifier(unit_objects)
+        verifier = get_verifiers(unit_objects)
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertTrue(result.success)
@@ -90,7 +90,7 @@ class CephOsdTests(BaseTestCase):
         check = "shutdown"
         unit_objects = loop.run(juju_verify.find_units(self.model, units))
         self._wait_to_ceph_cluster()
-        verifier = get_verifier(unit_objects)
+        verifier = get_verifiers(unit_objects)
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertFalse(result.success)
@@ -111,7 +111,7 @@ class CephOsdTests(BaseTestCase):
         self._add_test_pool(percent_data=80)
         self._wait_to_ceph_cluster()
         # check that Ceph cluster is healthy
-        verifier = get_verifier(unit_objects)
+        verifier = get_verifiers(unit_objects)
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertTrue(result.success)
@@ -131,7 +131,7 @@ class CephOsdTests(BaseTestCase):
         self._add_test_pool()
         self._wait_to_ceph_cluster(healthy=False)
         # check that Ceph cluster is unhealthy
-        verifier = get_verifier(unit_objects)
+        verifier = get_verifiers(unit_objects)
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertFalse(result.success)
@@ -150,7 +150,7 @@ class CephOsdTests(BaseTestCase):
         self._add_test_pool(percent_data=80)
         self._wait_to_ceph_cluster()
         # check that check_replication_number failed, due default min_size=2
-        verifier = get_verifier(unit_objects)
+        verifier = get_verifiers(unit_objects)
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertFalse(result.success)
@@ -168,7 +168,7 @@ class CephOsdTests(BaseTestCase):
             action_params={"name": "test", "key": "min_size", "value": "1"},
         )
         # check that check_replication_number passed
-        verifier = get_verifier(unit_objects)
+        verifier = get_verifiers(unit_objects)
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertFalse(result.success)
@@ -189,7 +189,7 @@ class CephMonTests(BaseTestCase):
         units = ["ceph-mon/0"]
         check = "shutdown"
         unit_objects = loop.run(juju_verify.find_units(self.model, units))
-        verifier = get_verifier(unit_objects)
+        verifier = get_verifiers(unit_objects)
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertTrue(result.success)
@@ -201,7 +201,7 @@ class CephMonTests(BaseTestCase):
         units = ["ceph-mon/0", "ceph-mon/1"]
         check = "shutdown"
         unit_objects = loop.run(juju_verify.find_units(self.model, units))
-        verifier = get_verifier(unit_objects)
+        verifier = get_verifiers(unit_objects)
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertFalse(result.success)

--- a/tests/functional/tests/test_ceph.py
+++ b/tests/functional/tests/test_ceph.py
@@ -63,7 +63,7 @@ class CephOsdTests(BaseTestCase):
         check = "shutdown"
         unit_objects = loop.run(find_units(self.model, units))
         self._wait_to_ceph_cluster()
-        verifier = get_verifiers(unit_objects)
+        verifier = next(get_verifiers(unit_objects))
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertTrue(result.success)
@@ -90,7 +90,7 @@ class CephOsdTests(BaseTestCase):
         check = "shutdown"
         unit_objects = loop.run(find_units(self.model, units))
         self._wait_to_ceph_cluster()
-        verifier = get_verifiers(unit_objects)
+        verifier = next(get_verifiers(unit_objects))
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertFalse(result.success)
@@ -111,7 +111,7 @@ class CephOsdTests(BaseTestCase):
         self._add_test_pool(percent_data=80)
         self._wait_to_ceph_cluster()
         # check that Ceph cluster is healthy
-        verifier = get_verifiers(unit_objects)
+        verifier = next(get_verifiers(unit_objects))
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertTrue(result.success)
@@ -131,7 +131,7 @@ class CephOsdTests(BaseTestCase):
         self._add_test_pool()
         self._wait_to_ceph_cluster(healthy=False)
         # check that Ceph cluster is unhealthy
-        verifier = get_verifiers(unit_objects)
+        verifier = next(get_verifiers(unit_objects))
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertFalse(result.success)
@@ -150,7 +150,7 @@ class CephOsdTests(BaseTestCase):
         self._add_test_pool(percent_data=80)
         self._wait_to_ceph_cluster()
         # check that check_replication_number failed, due default min_size=2
-        verifier = get_verifiers(unit_objects)
+        verifier = next(get_verifiers(unit_objects))
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertFalse(result.success)
@@ -168,7 +168,7 @@ class CephOsdTests(BaseTestCase):
             action_params={"name": "test", "key": "min_size", "value": "1"},
         )
         # check that check_replication_number passed
-        verifier = get_verifiers(unit_objects)
+        verifier = next(get_verifiers(unit_objects))
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertFalse(result.success)
@@ -189,7 +189,7 @@ class CephMonTests(BaseTestCase):
         units = ["ceph-mon/0"]
         check = "shutdown"
         unit_objects = loop.run(find_units(self.model, units))
-        verifier = get_verifiers(unit_objects)
+        verifier = next(get_verifiers(unit_objects))
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertTrue(result.success)
@@ -201,7 +201,7 @@ class CephMonTests(BaseTestCase):
         units = ["ceph-mon/0", "ceph-mon/1"]
         check = "shutdown"
         unit_objects = loop.run(find_units(self.model, units))
-        verifier = get_verifiers(unit_objects)
+        verifier = next(get_verifiers(unit_objects))
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertFalse(result.success)

--- a/tests/functional/tests/test_neutron_gateway.py
+++ b/tests/functional/tests/test_neutron_gateway.py
@@ -25,7 +25,7 @@ from neutronclient.v2_0.client import Client
 from tests.base import OpenstackBaseTestCase
 
 from juju_verify import juju_verify
-from juju_verify.verifiers import get_verifier
+from juju_verify.verifiers import get_verifiers
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ class NeutronTests(OpenstackBaseTestCase):
         """Test that shutdown of a single unit returns OK."""
         units = ["neutron-gateway/0"]
         unit_objects = loop.run(juju_verify.find_units(self.model, units))
-        verifier = get_verifier(unit_objects)
+        verifier = get_verifiers(unit_objects)
         result = verifier.verify(self.CHECK)
         logger.info("result: %s", result)
 
@@ -66,7 +66,7 @@ class NeutronTests(OpenstackBaseTestCase):
         """Test that stopping all neutron gateway returns failure."""
         units = ["neutron-gateway/0", "neutron-gateway/1"]
         unit_objects = loop.run(juju_verify.find_units(self.model, units))
-        verifier = get_verifier(unit_objects)
+        verifier = get_verifiers(unit_objects)
 
         # expected routers in error message
         routers = self.NEUTRON.list_routers().get("routers", [])
@@ -143,7 +143,7 @@ class NeutronTests(OpenstackBaseTestCase):
             "will be lost on unit shutdown:"
         )
 
-        verifier = get_verifier(units)
+        verifier = get_verifiers(units)
         result = verifier.verify_shutdown()
         logger.info("result: %s", result)
 

--- a/tests/functional/tests/test_neutron_gateway.py
+++ b/tests/functional/tests/test_neutron_gateway.py
@@ -56,7 +56,7 @@ class NeutronTests(OpenstackBaseTestCase):
         """Test that shutdown of a single unit returns OK."""
         units = ["neutron-gateway/0"]
         unit_objects = loop.run(find_units(self.model, units))
-        verifier = get_verifiers(unit_objects)
+        verifier = next(get_verifiers(unit_objects))
         result = verifier.verify(self.CHECK)
         logger.info("result: %s", result)
 
@@ -66,7 +66,7 @@ class NeutronTests(OpenstackBaseTestCase):
         """Test that stopping all neutron gateway returns failure."""
         units = ["neutron-gateway/0", "neutron-gateway/1"]
         unit_objects = loop.run(find_units(self.model, units))
-        verifier = get_verifiers(unit_objects)
+        verifier = next(get_verifiers(unit_objects))
 
         # expected routers in error message
         routers = self.NEUTRON.list_routers().get("routers", [])
@@ -141,7 +141,7 @@ class NeutronTests(OpenstackBaseTestCase):
             "will be lost on unit reboot/shutdown:"
         )
 
-        verifier = get_verifiers(units)
+        verifier = next(get_verifiers(units))
         result = verifier.verify_shutdown()
         logger.info("result: %s", result)
 

--- a/tests/functional/tests/test_novacompute.py
+++ b/tests/functional/tests/test_novacompute.py
@@ -37,7 +37,7 @@ class NovaCompute(OpenstackBaseTestCase):
         """Test that shutdown of a single unit returns OK."""
         units = ["nova-compute/0"]
         unit_objects = loop.run(find_units(self.model, units))
-        verifier = get_verifiers(unit_objects)
+        verifier = next(get_verifiers(unit_objects))
         result = verifier.verify(self.CHECK)
         logger.info("result: %s", result)
         self.assertTrue(result.success)
@@ -50,7 +50,7 @@ class NovaCompute(OpenstackBaseTestCase):
         should then trigger empty AZ error.
         """
         nova_application = self.model.applications.get("nova-compute")
-        verifier = get_verifiers(nova_application.units)
+        verifier = next(get_verifiers(nova_application.units))
         expected_partial = Partial(
             Severity.FAIL,
             "Removing these units would leave "
@@ -84,7 +84,7 @@ class NovaCompute(OpenstackBaseTestCase):
             Severity.FAIL, f"Unit {compute_with_vm} is running 1 VMs."
         )
         target_unit = loop.run(find_units(self.model, [compute_with_vm]))
-        verifier = get_verifiers(target_unit)
+        verifier = next(get_verifiers(target_unit))
 
         result = verifier.verify(self.CHECK)
         logger.info("result: %s", result)

--- a/tests/functional/tests/test_novacompute.py
+++ b/tests/functional/tests/test_novacompute.py
@@ -6,7 +6,7 @@ from juju import loop
 from tests.base import OpenstackBaseTestCase
 
 from juju_verify import juju_verify
-from juju_verify.verifiers import get_verifier
+from juju_verify.verifiers import get_verifiers
 from juju_verify.verifiers.result import Partial, Severity
 
 logger = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ class NovaCompute(OpenstackBaseTestCase):
         """Test that shutdown of a single unit returns OK."""
         units = ["nova-compute/0"]
         unit_objects = loop.run(juju_verify.find_units(self.model, units))
-        verifier = get_verifier(unit_objects)
+        verifier = get_verifiers(unit_objects)
         result = verifier.verify(self.CHECK)
         logger.info("result: %s", result)
         self.assertTrue(result.success)
@@ -50,7 +50,7 @@ class NovaCompute(OpenstackBaseTestCase):
         should then trigger empty AZ error.
         """
         nova_application = self.model.applications.get("nova-compute")
-        verifier = get_verifier(nova_application.units)
+        verifier = get_verifiers(nova_application.units)
         expected_partial = Partial(
             Severity.FAIL,
             "Removing these units would leave "
@@ -84,7 +84,7 @@ class NovaCompute(OpenstackBaseTestCase):
             Severity.FAIL, f"Unit {compute_with_vm} is running 1 VMs."
         )
         target_unit = loop.run(juju_verify.find_units(self.model, [compute_with_vm]))
-        verifier = get_verifier(target_unit)
+        verifier = get_verifiers(target_unit)
 
         result = verifier.verify(self.CHECK)
         logger.info("result: %s", result)

--- a/tests/unit/test_entrypoint.py
+++ b/tests/unit/test_entrypoint.py
@@ -264,7 +264,7 @@ def test_main_entrypoint_target_units(mocker):
     verifier.verify.return_value = result
 
     mocker.patch.object(juju_verify, "parse_args").return_value = args
-    mocker.patch.object(juju_verify, "get_verifier").return_value = verifier
+    mocker.patch.object(juju_verify, "get_verifiers").return_value = [verifier]
     mocker.patch.object(juju_verify, "loop")
     mocker.patch.object(juju_verify, "connect_model", new_callable=MagicMock())
     mocker.patch.object(juju_verify, "find_units", new_callable=MagicMock())
@@ -275,7 +275,7 @@ def test_main_entrypoint_target_units(mocker):
     juju_verify.connect_model.assert_called_with(args.model)
     juju_verify.find_units.assert_called_with(ANY, args.units)
     verifier.verify.asssert_called_with(args.check)
-    logger.info.assert_called_with(str(result))
+    logger.info.assert_called_with("%s", result)
 
 
 def test_main_entrypoint_target_machine(mocker):
@@ -293,7 +293,7 @@ def test_main_entrypoint_target_machine(mocker):
     verifier.verify.return_value = result
 
     mocker.patch.object(juju_verify, "parse_args").return_value = args
-    mocker.patch.object(juju_verify, "get_verifier").return_value = verifier
+    mocker.patch.object(juju_verify, "get_verifiers").return_value = [verifier]
     mocker.patch.object(juju_verify, "loop")
     mocker.patch.object(juju_verify, "connect_model", new_callable=MagicMock())
     mocker.patch.object(
@@ -306,7 +306,7 @@ def test_main_entrypoint_target_machine(mocker):
     juju_verify.connect_model.assert_called_with(args.model)
     juju_verify.find_units_on_machine.assert_called_with(ANY, args.machines)
     verifier.verify.asssert_called_with(args.check)
-    logger.info.assert_called_with(str(result))
+    logger.info.assert_called_with("%s", result)
 
 
 def test_main_entrypoint_no_target_fail(mocker, fail):
@@ -344,7 +344,7 @@ def test_main_expected_failure(mocker, fail, error, error_msg):
     mocker.patch.object(juju_verify, "loop")
     mocker.patch.object(juju_verify, "connect_model", new_callable=MagicMock())
     mocker.patch.object(juju_verify, "find_units", new_callable=MagicMock())
-    mocker.patch.object(juju_verify, "get_verifier").side_effect = error(error_msg)
+    mocker.patch.object(juju_verify, "get_verifiers").side_effect = [error(error_msg)]
 
     juju_verify.main()
 

--- a/tests/unit/verifiers/test_result.py
+++ b/tests/unit/verifiers/test_result.py
@@ -103,7 +103,7 @@ def test_result_formatting(severity):
     result = Result(partial_result.severity, partial_result.message)
 
     expected_success_msg = Result.VERBOSE_MAP.get(partial_result.severity)
-    expected_msg = "Checks:{0}{1}{0}{0}Overall result: {2}".format(
+    expected_msg = "Checks:{0}{1}{0}{0}Result: {2}{0}".format(
         os.linesep, partial_result, expected_success_msg
     )
 


### PR DESCRIPTION
 - get_verifier -> get_verifiers (iterable object)
 - group units by charms type and separate output with "===[<unit>, ...]==="
 - run `for verifier in get_verifiers(units):`
 - remove "Overall" from result string definition

Example: https://pastebin.canonical.com/p/n7V9VxhmmS/
Fixes: https://bugs.launchpad.net/juju-verify/+bug/1951620