### PR TITLE
[cache] fix run action

### DIFF
--- a/juju_verify/cli.py
+++ b/juju_verify/cli.py
@@ -134,7 +134,9 @@ def config_logger(log_level: str) -> None:
         root_logger.setLevel(logging.DEBUG)
         juju_verify_logger.setLevel(logging.DEBUG)
     elif log_level == "debug":
-        stream_handler.setFormatter(logging.Formatter("| %(levelname)s | %(message)s"))
+        stream_handler.setFormatter(
+            logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+        )
         root_logger.setLevel(logging.INFO)
         # set DEBUG level only for juju-verify logger
         juju_verify_logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
- move cache_manager into run_action function
  These changes are necessary because when the cache_manager was outside the run_action function, which is asynchronous, the cache was not used at all.
- add time into DEBUG log message