### PR TITLE
Openstack model update

### DIFF
--- a/juju_verify/cli.py
+++ b/juju_verify/cli.py
@@ -37,7 +37,7 @@ from juju_verify.verifiers import BaseVerifier, get_verifiers
 from juju_verify.verifiers.result import set_stop_on_failure
 
 # set MAX_FRAME_SIZE to 64MB to connect python-libjuju to the model
-JUJU_MAX_FRAME_SIZE = 2 ** 26
+JUJU_MAX_FRAME_SIZE = 2**26
 logger = logging.getLogger(__name__)
 
 

--- a/tests/functional/tests/bundles/ceph.yaml
+++ b/tests/functional/tests/bundles/ceph.yaml
@@ -1,3 +1,8 @@
+variables:
+  # We are using `candidate` channel for charm that do not support bionic
+  # release in `stable`
+  channel: &channel candidate
+
 series: bionic
 machines:
   '0':
@@ -14,7 +19,8 @@ machines:
     constraints: cores=1 mem=2G root-disk=20G
 applications:
   ceph-mon:
-    charm: cs:~openstack-charmers-next/ceph-mon
+    charm: ceph-mon
+    channel: *channel
     num_units: 3
     options:
       expected-osd-count: 3
@@ -24,7 +30,8 @@ applications:
     - lxd:1
     - lxd:2
   ceph-osd-hdd:
-    charm: cs:~openstack-charmers-next/ceph-osd
+    charm: ceph-osd
+    channel: *channel
     num_units: 3
     options:
       osd-devices: /dev/loop0
@@ -35,7 +42,8 @@ applications:
       - 1
       - 2
   ceph-osd-ssd:
-    charm: cs:~openstack-charmers-next/ceph-osd
+    charm: ceph-osd
+    channel: *channel
     num_units: 3
     options:
       osd-devices: /dev/loop0

--- a/tests/functional/tests/bundles/openstack.yaml
+++ b/tests/functional/tests/bundles/openstack.yaml
@@ -1,5 +1,8 @@
 variables:
   openstack-origin: &openstack-origin distro
+  # We are using `candidate` channel for charm that do not support bionic
+  # release in `stable`
+  channel: &channel candidate
 
 series: &series bionic
 
@@ -29,7 +32,7 @@ applications:
       - '0'
   rabbitmq-server:
     charm: rabbitmq-server
-    channel: candidate
+    channel: *channel
     num_units: 1
     options:
       source: *openstack-origin
@@ -37,7 +40,7 @@ applications:
       - '1'
   neutron-api:
     charm: neutron-api
-    channel: candidate
+    channel: *channel
     series: *series
     num_units: 1
     options:
@@ -48,7 +51,7 @@ applications:
       - '2'
   keystone:
     charm: keystone
-    channel: candidate
+    channel: *channel
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -56,7 +59,7 @@ applications:
       - '3'
   glance:
     charm: glance
-    channel: candidate
+    channel: *channel
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -64,10 +67,10 @@ applications:
       - '4'
   neutron-openvswitch:
     charm: neutron-openvswitch
-    channel: candidate
+    channel: *channel
   neutron-gateway:
     charm: neutron-gateway
-    channel: candidate
+    channel: *channel
     num_units: 2
     options:
       bridge-mappings: physnet1:br-ex
@@ -77,7 +80,7 @@ applications:
       - '6'
   nova-cloud-controller:
     charm: nova-cloud-controller
-    channel: candidate
+    channel: *channel
     num_units: 1
     options:
       network-manager: Neutron
@@ -86,7 +89,7 @@ applications:
       - '7'
   nova-compute:
     charm: nova-compute
-    channel: candidate
+    channel: *channel
     num_units: 2
     options:
       openstack-origin: *openstack-origin

--- a/tests/functional/tests/bundles/openstack.yaml
+++ b/tests/functional/tests/bundles/openstack.yaml
@@ -21,21 +21,23 @@ machines:
 # time, given that machine "0" comes up way before machine "7"
 applications:
   percona-cluster:
-    charm: cs:~openstack-charmers-next/percona-cluster
+    charm: percona-cluster
     num_units: 1
     options:
       source: *openstack-origin
     to:
       - '0'
   rabbitmq-server:
-    charm: cs:~openstack-charmers-next/rabbitmq-server
+    charm: rabbitmq-server
+    channel: candidate
     num_units: 1
     options:
       source: *openstack-origin
     to:
       - '1'
   neutron-api:
-    charm: cs:~openstack-charmers-next/neutron-api
+    charm: neutron-api
+    channel: candidate
     series: *series
     num_units: 1
     options:
@@ -45,23 +47,27 @@ applications:
     to:
       - '2'
   keystone:
-    charm: cs:~openstack-charmers-next/keystone
+    charm: keystone
+    channel: candidate
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
       - '3'
   glance:
-    charm: cs:~openstack-charmers-next/glance
+    charm: glance
+    channel: candidate
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
       - '4'
   neutron-openvswitch:
-    charm: cs:~openstack-charmers-next/neutron-openvswitch
+    charm: neutron-openvswitch
+    channel: candidate
   neutron-gateway:
-    charm: cs:~openstack-charmers-next/neutron-gateway
+    charm: neutron-gateway
+    channel: candidate
     num_units: 2
     options:
       bridge-mappings: physnet1:br-ex
@@ -70,7 +76,8 @@ applications:
       - '5'
       - '6'
   nova-cloud-controller:
-    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    charm: nova-cloud-controller
+    channel: candidate
     num_units: 1
     options:
       network-manager: Neutron
@@ -78,7 +85,8 @@ applications:
     to:
       - '7'
   nova-compute:
-    charm: cs:~openstack-charmers-next/nova-compute
+    charm: nova-compute
+    channel: candidate
     num_units: 2
     options:
       openstack-origin: *openstack-origin


### PR DESCRIPTION
With switch over to the https://charmhub.io a new naming scheme is used for charms. A name of the promulgated charm is enough but we now must specify `candidate` channel for the Openstack charms, as the (default) `stable` channel does not have `bionic` releases.

This change also includes the one-liner change from #64, but neither PR can be merge without the other change so I think it's fine it that simple change is included in this PR.