### PR TITLE
Add option to explicitly map application to charm type.

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -63,11 +63,11 @@ Description of CLI
 After successfully installing ``juju-verify``, help instructions can be
 displayed using this command::
 
-  juju-verify --help
+  $ juju verify --help
   usage: juju-verify [-h] [--model MODEL] [-l {trace,debug,info}] [-s]
-                   [--map-charm MAP_CHARM]
-                   (--units UNITS [UNITS ...] | --machines MACHINES [MACHINES ...])
-                   {shutdown,reboot}
+                     [--map-charm MAP_CHARM]
+                     (--units UNITS [UNITS ...] | --machines MACHINES [MACHINES ...])
+                     {shutdown,reboot}
 
   Verify that it's safe to perform selected action on specified units.
   Currently supported charms are:
@@ -89,12 +89,12 @@ displayed using this command::
                           Stop running checks after a failed one.
     --map-charm MAP_CHARM
                           WARNING: This option can lead to failed verifications
-                          when used incorrectly. This option allows user to
-                          explicitly specify which charm is the application
-                          running. It is useful when charm is deployed from
-                          local source or from non-official charmhub repository.
-                          Expected value format is <APP_NAME>:<CHARM_NAME>. For
-                          list of supported charms, see description in --help
+                          when used incorrectly. This option allows users to
+                          explicitly specify the charm used by an application.
+                          Typical use cases involve the usage of local charms or
+                          non-official charmhub repositories. Expected value
+                          format is <APP_NAME>:<CHARM_NAME>. For list of
+                          supported charms, see description in --help
     --units UNITS [UNITS ...], -u UNITS [UNITS ...]
                           Units to check.
     --machines MACHINES [MACHINES ...], -M MACHINES [MACHINES ...]
@@ -171,7 +171,7 @@ With ``--stop-on-failure``
 Charm mapping
 """""""""""""
 
-This option enables user to explicitly tell ``juju-verify`` which charm a
+This option enables the user to explicitly tell ``juju-verify`` which charm a
 specific application deploys.
 
 By default, ``juju-verify`` parses URL from which the charm was deployed to
@@ -179,14 +179,17 @@ identify the charm. However this may fail if charm was deployed from local
 source or from non-official charmstore repository. In such cases, this option
 can be used to specify which charm is an application deploying.
 
-For example if you'd deploy ``ceph-osd`` charm to ``ceph-osd-ssd`` application
-**from local source**, you could do following command to verify it:
+For example, if the ``ceph-osd`` charm uses a local path to deploy the
+``ceph-osd-ssd`` application, the following command could be used to verify
+units of the mentioned application:
 
 ::
 
   $ juju-verify reboot --unit ceph-osd-ssd/0 --map-charm ceph-osd-ssd:ceph-osd
 
-To get list of supported charms that can be mapped to applications, see --help
+The charm name specified via this option must be one of the charms supported by
+``juju-verify``. To get list of supported charms that can be mapped to
+applications, see description in ``--help`` output.
 
 ::
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -64,9 +64,17 @@ After successfully installing ``juju-verify``, help instructions can be
 displayed using this command::
 
   juju-verify --help
-  usage: juju-verify [-h] [--model MODEL] [-l {trace,debug,info}] [-s] (--units UNITS [UNITS ...] | --machines MACHINES [MACHINES ...]) {shutdown,reboot}
+  usage: juju-verify [-h] [--model MODEL] [-l {trace,debug,info}] [-s]
+                   [--map-charm MAP_CHARM]
+                   (--units UNITS [UNITS ...] | --machines MACHINES [MACHINES ...])
+                   {shutdown,reboot}
 
-  Verify that it's safe to perform selected action on specified units
+  Verify that it's safe to perform selected action on specified units.
+  Currently supported charms are:
+    * nova-compute
+    * ceph-osd
+    * ceph-mon
+    * neutron-gateway
 
   positional arguments:
     {shutdown,reboot}     Check to verify.
@@ -79,6 +87,14 @@ displayed using this command::
                           Set amount of displayed information
     -s, --stop-on-failure
                           Stop running checks after a failed one.
+    --map-charm MAP_CHARM
+                          WARNING: This option can lead to failed verifications
+                          when used incorrectly. This option allows user to
+                          explicitly specify which charm is the application
+                          running. It is useful when charm is deployed from
+                          local source or from non-official charmhub repository.
+                          Expected value format is <APP_NAME>:<CHARM_NAME>. For
+                          list of supported charms, see description in --help
     --units UNITS [UNITS ...], -u UNITS [UNITS ...]
                           Units to check.
     --machines MACHINES [MACHINES ...], -M MACHINES [MACHINES ...]
@@ -151,6 +167,33 @@ With ``--stop-on-failure``
   [FAIL] The minimum number of replicas in 'ceph-osd' is 1 and it's not safe to reboot/shutdown 2 units. 0 units are not active.
 
   Result: Failed
+
+Charm mapping
+"""""""""""""
+
+This option enables user to explicitly tell ``juju-verify`` which charm a
+specific application deploys.
+
+By default, ``juju-verify`` parses URL from which the charm was deployed to
+identify the charm. However this may fail if charm was deployed from local
+source or from non-official charmstore repository. In such cases, this option
+can be used to specify which charm is an application deploying.
+
+For example if you'd deploy ``ceph-osd`` charm to ``ceph-osd-ssd`` application
+**from local source**, you could do following command to verify it:
+
+::
+
+  $ juju-verify reboot --unit ceph-osd-ssd/0 --map-charm ceph-osd-ssd:ceph-osd
+
+To get list of supported charms that can be mapped to applications, see --help
+
+::
+
+  $ juju-verify --help
+
+This option can be repeated multiple times if there's a need to specify mappings
+of multiple application.
 
 Usage examples
 ^^^^^^^^^^^^^^

--- a/juju_verify/cli.py
+++ b/juju_verify/cli.py
@@ -142,9 +142,9 @@ def parse_args() -> argparse.Namespace:
         default=[],
         type=parse_charm_mapping,
         help="WARNING: This option can lead to failed verifications when used "
-        "incorrectly. This option allows user to explicitly specify which charm is"
-        " the application running. It is useful when charm is deployed from local"
-        " source or from non-official charmhub repository. Expected value format"
+        "incorrectly. This option allows users to explicitly specify the charm used"
+        " by an application. Typical use cases involve the usage of local charms or"
+        " non-official charmhub repositories. Expected value format"
         " is <APP_NAME>:<CHARM_NAME>. For list of supported charms, see description"
         " in --help",
     )

--- a/juju_verify/verifiers/__init__.py
+++ b/juju_verify/verifiers/__init__.py
@@ -58,7 +58,7 @@ def get_verifiers(
 
     charm_map = charm_map or []
     charms = defaultdict(list)
-    mapped_applications = {mapping[0]: mapping[1] for mapping in charm_map}
+    mapped_applications = dict(charm_map)
 
     for unit in units:
         unit_application = unit.data.get("application")
@@ -66,7 +66,7 @@ def get_verifiers(
             # Assign charm type based on explicit mapping
             charm_type = mapped_applications[unit_application]
             logger.debug(
-                "Using explicitly defined charm for " "unit %s: %s",
+                "Using explicitly defined charm for unit %s: %s",
                 unit.entity_id,
                 charm_type,
             )

--- a/tests/unit/verifiers/test_init.py
+++ b/tests/unit/verifiers/test_init.py
@@ -44,6 +44,24 @@ def test_get_verifier_supported_charms(model, charm, verifier_type):
         assert verifier.units == units
 
 
+def test_get_verifier_explicit_charm_mapping(mocker):
+    """Test get_verifiers with explicitly mapped charm."""
+    unknown_origin = "ch:amd64/focal/personal-nova-compute"
+    application = "nova-compute-dev"
+    explicit_application = "nova-compute"
+    expected_verifier = NovaCompute
+
+    charm_mapping = [(application, explicit_application)]
+
+    nova_unit = mocker.MagicMock()
+    nova_unit.entity_id = f"{application}/0"
+    nova_unit.data = {"charm-url": unknown_origin, "application": application}
+
+    for verifier in get_verifiers([nova_unit], charm_mapping):
+        assert isinstance(verifier, expected_verifier)
+        assert verifier.units == [nova_unit]
+
+
 def test_get_verifier_unsupported_charm(mocker, model):
     """Raise exception if unsupported charm is requested."""
     mock_logger = mocker.patch("juju_verify.verifiers.logger")


### PR DESCRIPTION
This is usefull when applications are deployed from
local sources or from private repositories.

For more info see [LP#1960331](https://bugs.launchpad.net/juju-verify/+bug/1960331)