### PR TITLE
Adapt to changes in libjuju3 and zaza

### DIFF
--- a/juju_verify/utils/action.py
+++ b/juju_verify/utils/action.py
@@ -28,7 +28,7 @@ def data_from_action(action: Action, key: str, default: str = "") -> str:
     :param default: default value to return if the 'key' is not found
     :return: value from the action's results identified by 'key' or default
     """
-    return action.data.get("results", {}).get(key, default)
+    return action.results.get(key, default)
 
 
 cache_manager = CacheManager(enabled=True)

--- a/juju_verify/utils/unit.py
+++ b/juju_verify/utils/unit.py
@@ -121,7 +121,7 @@ def run_action_on_units(
             )
 
         logger.debug(
-            "Action %s (ID: %s) finished with status %s. Action results " "`%s`.",
+            "Action %s (ID: %s) finished with status %s. Action results `%s`.",
             action,
             action_result.entity_id,
             action_result.status,

--- a/tests/functional/tests/configure/ceph.py
+++ b/tests/functional/tests/configure/ceph.py
@@ -22,7 +22,6 @@ from typing import Dict, List, Optional
 
 import zaza
 import zaza.model as model
-from juju.model import Model
 
 from juju_verify.utils.unit import find_unit_by_hostname
 

--- a/tests/functional/tests/configure/ceph.py
+++ b/tests/functional/tests/configure/ceph.py
@@ -31,8 +31,7 @@ logger = logging.getLogger(__name__)
 
 def _get_osd_map() -> Dict[str, List[str]]:
     """Get map between ceph-osd unit and osd."""
-    juju_model = Model()
-    zaza.run(juju_model.connect(model_name=model.get_juju_model()))
+    juju_model = zaza.sync_wrapper(model.get_model)()
     action = model.run_action_on_leader(
         "ceph-mon", "show-disk-free", action_params={"format": "json"}
     )
@@ -47,7 +46,7 @@ def _get_osd_map() -> Dict[str, List[str]]:
                 logger.debug("found osd `%s` for unit `%s`", child, unit)
                 osd_map[unit.entity_id].append(ceph_tree[child]["name"])
 
-    zaza.run(juju_model.disconnect())
+    zaza.sync_wrapper(juju_model.disconnect)()
     return osd_map
 
 

--- a/tests/unit/utils/test_action.py
+++ b/tests/unit/utils/test_action.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License along with
 # this program. If not, see https://www.gnu.org/licenses/.
 """Juju action helpers test suite."""
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import MagicMock
 
 from juju.action import Action
 
@@ -26,11 +26,11 @@ def test_data_from_action(mocker):
     """Test helper function that parses data from Action.data.results dict."""
     host_key = "host"
     host_value = "compute.0"
-    data = {"results": {host_key: host_value}}
+    data = {host_key: host_value}
     default = "default"
 
-    mocker.patch.object(Action, "data", new_callable=PropertyMock(return_value=data))
     action = Action("0", MagicMock())
+    action.results = data
 
     output = data_from_action(action, host_key, default)
     assert output == host_value

--- a/tests/unit/verifiers/test_ceph.py
+++ b/tests/unit/verifiers/test_ceph.py
@@ -237,7 +237,7 @@ def test_ceph_tree(exp_child, exp_parent, ancestor_type, can_remove_host_node):
 def test_check_cluster_health(mock_run_action_on_units, message, exp_result, model):
     """Test check Ceph cluster health."""
     action = MagicMock()
-    action.data.get.side_effect = {"results": {"message": message}}.get
+    action.results = {"message": message}
     mock_run_action_on_units.return_value = {"ceph-mon/0": action}
 
     result = CephCommon.check_cluster_health(model.units["ceph-mon/0"])
@@ -255,9 +255,9 @@ def test_check_cluster_health_combination(mock_run_action_on_units, model):
     )
 
     action_healthy = MagicMock()
-    action_healthy.data.get.side_effect = {"results": {"message": "HEALTH_OK"}}.get
+    action_healthy.results = {"message": "HEALTH_OK"}
     action_unhealthy = MagicMock()
-    action_unhealthy.data.get.side_effect = {"results": {"message": "HEALTH_ERR"}}.get
+    action_unhealthy.results = {"message": "HEALTH_ERR"}
     mock_run_action_on_units.return_value = {
         "ceph-mon/0": action_healthy,
         "ceph-mon/1": action_unhealthy,
@@ -406,41 +406,39 @@ def test_count_branch(model):
 def test_get_crush_rules(mock_run_command_on_unit, model):
     """Test get all crush rules in Ceph cluster."""
     action = MagicMock()
-    action.data.get.side_effect = {
-        "results": {
-            "Stdout": "\n"
-            + json.dumps(
-                [
-                    {
-                        "rule_id": 0,
-                        "rule_name": "replicated_rule",
-                        "ruleset": 0,
-                        "type": 1,
-                        "min_size": 1,
-                        "max_size": 10,
-                        "steps": [
-                            {"op": "take", "item": -1, "item_name": "default"},
-                            {"op": "chooseleaf_firstn", "num": 0, "type": "host"},
-                            {"op": "emit"},
-                        ],
-                    },
-                    {
-                        "rule_id": 1,
-                        "rule_name": "hdd",
-                        "ruleset": 1,
-                        "type": 1,
-                        "min_size": 1,
-                        "max_size": 10,
-                        "steps": [
-                            {"op": "take", "item": -2, "item_name": "default~hdd"},
-                            {"op": "chooseleaf_firstn", "num": 0, "type": "rack"},
-                            {"op": "emit"},
-                        ],
-                    },
-                ]
-            )
-        }
-    }.get
+    action.results = {
+        "Stdout": "\n"
+        + json.dumps(
+            [
+                {
+                    "rule_id": 0,
+                    "rule_name": "replicated_rule",
+                    "ruleset": 0,
+                    "type": 1,
+                    "min_size": 1,
+                    "max_size": 10,
+                    "steps": [
+                        {"op": "take", "item": -1, "item_name": "default"},
+                        {"op": "chooseleaf_firstn", "num": 0, "type": "host"},
+                        {"op": "emit"},
+                    ],
+                },
+                {
+                    "rule_id": 1,
+                    "rule_name": "hdd",
+                    "ruleset": 1,
+                    "type": 1,
+                    "min_size": 1,
+                    "max_size": 10,
+                    "steps": [
+                        {"op": "take", "item": -2, "item_name": "default~hdd"},
+                        {"op": "chooseleaf_firstn", "num": 0, "type": "rack"},
+                        {"op": "emit"},
+                    ],
+                },
+            ]
+        )
+    }
     mock_run_command_on_unit.return_value = action
     crush_rules = CephCommon.get_crush_rules(model.units["ceph-mon/0"])
 
@@ -456,32 +454,30 @@ def test_get_crush_rules(mock_run_command_on_unit, model):
 def test_get_ceph_pools(mock_run_action_on_unit, mock_get_crush_rules, model):
     """Test get detail about Ceph pools."""
     action = MagicMock()
-    action.data.get.side_effect = {
-        "results": {
-            "message": json.dumps(
-                [
-                    {
-                        "pool": 2,
-                        "pool_name": "ssd",
-                        "type": 1,
-                        "size": 3,
-                        "min_size": 2,
-                        "crush_rule": 2,
-                        "erasure_code_profile": "",
-                    },
-                    {
-                        "pool": 3,
-                        "pool_name": "hdd",
-                        "type": 1,
-                        "size": 3,
-                        "min_size": 2,
-                        "crush_rule": 2,
-                        "erasure_code_profile": "",
-                    },
-                ]
-            )
-        }
-    }.get
+    action.results = {
+        "message": json.dumps(
+            [
+                {
+                    "pool": 2,
+                    "pool_name": "ssd",
+                    "type": 1,
+                    "size": 3,
+                    "min_size": 2,
+                    "crush_rule": 2,
+                    "erasure_code_profile": "",
+                },
+                {
+                    "pool": 3,
+                    "pool_name": "hdd",
+                    "type": 1,
+                    "size": 3,
+                    "min_size": 2,
+                    "crush_rule": 2,
+                    "erasure_code_profile": "",
+                },
+            ]
+        )
+    }
     mock_run_action_on_unit.return_value = action
     mock_get_crush_rules.return_value = {2: CrushRuleInfo(2, "test", "host")}
 
@@ -498,84 +494,82 @@ def test_get_ceph_pools(mock_run_action_on_unit, mock_get_crush_rules, model):
 def test_get_disk_utilization(mock_run_action_on_unit, model):
     """Test get disk utilization for ceph."""
     action = MagicMock()
-    action.data.get.side_effect = {
-        "results": {
-            "message": json.dumps(
-                {
-                    "nodes": [
-                        {
-                            "id": -1,
-                            "name": "default",
-                            "type": "root",
-                            "type_id": 10,
-                            "reweight": -1.000000,
-                            "kb": 31457280,
-                            "kb_used": 3154944,
-                            "kb_used_data": 9024,
-                            "kb_used_omap": 0,
-                            "kb_used_meta": 3145728,
-                            "kb_avail": 28302336,
-                            "utilization": 10.029297,
-                            "var": 1.000000,
-                            "pgs": 0,
-                            "children": [-7, -3, -5],
-                        },
-                        {
-                            "id": -3,
-                            "name": "juju-2ecfef-zaza-a0e73f67a6c0-1",
-                            "type": "host",
-                            "type_id": 1,
-                            "pool_weights": {},
-                            "reweight": -1.000000,
-                            "kb": 10485760,
-                            "kb_used": 1051648,
-                            "kb_used_data": 3008,
-                            "kb_used_omap": 0,
-                            "kb_used_meta": 1048576,
-                            "kb_avail": 9434112,
-                            "utilization": 10.029297,
-                            "var": 1.000000,
-                            "pgs": 0,
-                            "children": [0],
-                        },
-                        {
-                            "id": 0,
-                            "device_class": "hdd",
-                            "name": "osd.0",
-                            "type": "osd",
-                            "type_id": 0,
-                            "crush_weight": 0.009796,
-                            "depth": 2,
-                            "pool_weights": {},
-                            "reweight": 1.000000,
-                            "kb": 10485760,
-                            "kb_used": 1051648,
-                            "kb_used_data": 3008,
-                            "kb_used_omap": 0,
-                            "kb_used_meta": 1048576,
-                            "kb_avail": 9434112,
-                            "utilization": 10.029297,
-                            "var": 1.000000,
-                            "pgs": 0,
-                        },
-                    ],
-                    "stray": [],
-                    "summary": {
-                        "total_kb": 31457280,
-                        "total_kb_used": 3154944,
-                        "total_kb_used_data": 9024,
-                        "total_kb_used_omap": 0,
-                        "total_kb_used_meta": 3145728,
-                        "total_kb_avail": 28302336,
-                        "average_utilization": 10.029297,
-                        "min_var": 1.000000,
-                        "max_var": 1.000000,
-                        "dev": 0.000000,
+    action.results = {
+        "message": json.dumps(
+            {
+                "nodes": [
+                    {
+                        "id": -1,
+                        "name": "default",
+                        "type": "root",
+                        "type_id": 10,
+                        "reweight": -1.000000,
+                        "kb": 31457280,
+                        "kb_used": 3154944,
+                        "kb_used_data": 9024,
+                        "kb_used_omap": 0,
+                        "kb_used_meta": 3145728,
+                        "kb_avail": 28302336,
+                        "utilization": 10.029297,
+                        "var": 1.000000,
+                        "pgs": 0,
+                        "children": [-7, -3, -5],
                     },
-                }
-            )
-        }
-    }.get
+                    {
+                        "id": -3,
+                        "name": "juju-2ecfef-zaza-a0e73f67a6c0-1",
+                        "type": "host",
+                        "type_id": 1,
+                        "pool_weights": {},
+                        "reweight": -1.000000,
+                        "kb": 10485760,
+                        "kb_used": 1051648,
+                        "kb_used_data": 3008,
+                        "kb_used_omap": 0,
+                        "kb_used_meta": 1048576,
+                        "kb_avail": 9434112,
+                        "utilization": 10.029297,
+                        "var": 1.000000,
+                        "pgs": 0,
+                        "children": [0],
+                    },
+                    {
+                        "id": 0,
+                        "device_class": "hdd",
+                        "name": "osd.0",
+                        "type": "osd",
+                        "type_id": 0,
+                        "crush_weight": 0.009796,
+                        "depth": 2,
+                        "pool_weights": {},
+                        "reweight": 1.000000,
+                        "kb": 10485760,
+                        "kb_used": 1051648,
+                        "kb_used_data": 3008,
+                        "kb_used_omap": 0,
+                        "kb_used_meta": 1048576,
+                        "kb_avail": 9434112,
+                        "utilization": 10.029297,
+                        "var": 1.000000,
+                        "pgs": 0,
+                    },
+                ],
+                "stray": [],
+                "summary": {
+                    "total_kb": 31457280,
+                    "total_kb_used": 3154944,
+                    "total_kb_used_data": 9024,
+                    "total_kb_used_omap": 0,
+                    "total_kb_used_meta": 3145728,
+                    "total_kb_avail": 28302336,
+                    "average_utilization": 10.029297,
+                    "min_var": 1.000000,
+                    "max_var": 1.000000,
+                    "dev": 0.000000,
+                },
+            }
+        )
+    }
     mock_run_action_on_unit.return_value = action
 
     nodes = CephCommon.get_disk_utilization(model.units["ceph-mon/0"])
@@ -1037,7 +1031,7 @@ def test_verify_shutdown(
 def test_parse_quorum_status(action_output, exp_output):
     """Test function to parse `get-quorum-status` action output."""
     mock_action = MagicMock()
-    mock_action.data = {"results": {"message": action_output}}
+    mock_action.results = {"message": action_output}
 
     unit = Unit("ceph-mon/0", Model())
     verifier = CephMon([unit])

--- a/tests/unit/verifiers/test_nova_compute.py
+++ b/tests/unit/verifiers/test_nova_compute.py
@@ -38,9 +38,9 @@ def test_nova_compute_no_running_vms(mocker, vm_count, expect_severity):
     units = [Unit(name, model) for name in unit_names]
 
     # Mock result of 'instance-count' action on all verified units.
-    result_data = {"results": {"instance-count": vm_count}}
+    result_data = {"instance-count": vm_count}
     mock_result = MagicMock()
-    mock_result.data = result_data
+    mock_result.results = result_data
     action_results = {unit: mock_result for unit in unit_names}
     mocker.patch.object(NovaCompute, "run_action_on_all").return_value = action_results
 
@@ -113,7 +113,7 @@ def test_nova_compute_empty_az(
     node_name_results = []
     for node in host_pool[:remove_hosts]:
         result_mock = MagicMock()
-        result_mock.data = {"results": {"node-name": node}}
+        result_mock.results = {"node-name": node}
         node_name_results.append(result_mock)
     action_results = dict(zip(unit_names, node_name_results))
 
@@ -125,9 +125,9 @@ def test_nova_compute_empty_az(
         for host in host_pool[:all_hosts]
     ]
 
-    compute_nodes_data = {"results": {"compute-nodes": json.dumps(raw_compute_nodes)}}
+    compute_nodes_data = {"compute-nodes": json.dumps(raw_compute_nodes)}
     mock_compute_node_result = MagicMock()
-    mock_compute_node_result.data = compute_nodes_data
+    mock_compute_node_result.results = compute_nodes_data
     mocker.patch(
         "juju_verify.verifiers.nova_compute.run_action_on_unit"
     ).return_value = mock_compute_node_result


### PR DESCRIPTION
These changes reflect changes that were made to juju library and zaza framework.

- `juju.Action` object has simplified access to action results via `results` attribute and no longer needs to search `self.data`. This change makes our helper function `data_from_action` likely obsolete and we should phase it out.
- `zaza.run()` function was removed, and although it was later re-added with slightly different functionality, I think that we can use the alternative `sync_wrapper` method.