### PR TITLE
Deploy ceph-mon on separate focal machine

### DIFF
--- a/.github/workflows/tests_full.yml
+++ b/.github/workflows/tests_full.yml
@@ -165,6 +165,6 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Run func tests
         run: tox -e func

--- a/tests/functional/tests/bundles/ceph.yaml
+++ b/tests/functional/tests/bundles/ceph.yaml
@@ -17,6 +17,8 @@ machines:
     constraints: cores=1 mem=2G root-disk=20G
   '5':
     constraints: cores=1 mem=2G root-disk=20G
+  '6':
+    series: focal
 applications:
   ceph-mon:
     charm: ceph-mon
@@ -26,9 +28,9 @@ applications:
       expected-osd-count: 3
       monitor-count: 3
     to:
-    - lxd:0
-    - lxd:1
-    - lxd:2
+    - lxd:6
+    - lxd:6
+    - lxd:6
   ceph-osd-hdd:
     charm: ceph-osd
     channel: *channel

--- a/tests/functional/tests/test_ceph.py
+++ b/tests/functional/tests/test_ceph.py
@@ -8,7 +8,7 @@ import zaza
 from tests.base import BaseTestCase
 
 from juju_verify.utils.action import cache_manager
-from juju_verify.verifiers import Severity, get_verifiers
+from juju_verify.verifiers import get_verifiers
 from juju_verify.verifiers.result import Result
 
 logger = logging.getLogger(__name__)
@@ -97,11 +97,6 @@ class CephOsdTests(BaseTestCase):
         result = verifier.verify(check)
         logger.info("result: %s", result)
         self.assertTrue(result.success)
-        self.assert_message_in_result(
-            r"\[WARN\] ceph-osd-hdd\/\d has units running on child machines: "
-            r"ceph-mon\/\d",
-            result,
-        )
 
     def test_pool_with_multiple_failure_domain(self):
         """Test multiple pools with different failure-domain."""
@@ -148,9 +143,6 @@ class CephOsdTests(BaseTestCase):
         verifier = next(get_verifiers(units))
         result = verifier.verify(check)
         logger.info("result: %s", result)
-        self.assertTrue(
-            any(partial.severity == Severity.WARN for partial in result.partials)
-        )
         self.assert_message_in_result(
             r"\[FAIL\] ceph-mon\/\d: Ceph cluster is in a warning state",
             result,


### PR DESCRIPTION
There are currently problems with running LXCs on bionic units. This workaround solves this issue by deploying ceph-mon units on separate focal machine.

Since ceph-mon units are no longer deployed on the same machines as ceph-osd, running ceph-osd verifier no longer produces warnings about other units running on the machines.