### PR TITLE
fixing CI build process

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -45,6 +45,8 @@ jobs:
     needs: lint-unittests-docs
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -24,6 +24,8 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/tests_full.yml
+++ b/.github/workflows/tests_full.yml
@@ -142,6 +142,8 @@ jobs:
       || github.event.review.body == 'recheck-full'
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - uses: snapcore/action-build@v1
       id: snapcraft
     - name: Install snap

--- a/.github/workflows/tests_full.yml
+++ b/.github/workflows/tests_full.yml
@@ -113,6 +113,8 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -158,6 +160,8 @@ jobs:
       || github.event.review.body == 'recheck-full'
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tests_smoke.yml
+++ b/.github/workflows/tests_smoke.yml
@@ -17,6 +17,8 @@ jobs:
         python-version: ["3.8", "3.10"]
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/tests_smoke.yml
+++ b/.github/workflows/tests_smoke.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
 
 jobs:
-  lint-unittests-docs-build:
+  lint-unittests-docs:
     name: Lint and Unit tests
     runs-on: ubuntu-latest
     strategy:
@@ -29,3 +29,5 @@ jobs:
       run: tox -e lint
     - name: Run unit tests
       run: tox -e unit
+    - name: Build docs
+      run: tox -e docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 [metadata]
 name = juju-verify
 # See setup.py version generator
-#version = 0.2
 url = https://launchpad.net/juju-verify
 description = Juju plugin to verify if it is safe to perform an operation on one or more units
 long_description = file: README.md

--- a/setup.py
+++ b/setup.py
@@ -20,16 +20,22 @@ import subprocess
 from typing import List
 
 
-def find_version(filename: str = "version") -> str:
-    """Parse the version and build details stored in the 'version' file."""
+def find_version() -> str:
+    """Parse juju-verify version based on the git tag."""
     try:
         cmd: List[str] = ["git", "describe", "--tags", "--always", "HEAD"]
         gitversion: str = subprocess.check_output(
             cmd, stderr=subprocess.DEVNULL
         ).decode().strip()
-        build: List[str] = gitversion.split("-")
-        # <tagname>-<ncommits-ahead>-<commit-id> (e.g. 0.2-8-adfebee)
-        return "{}.post{}".format(build[0], build[1])
+        if all(char.isdigit() or char == "." for char in gitversion):
+            # gitversion in tagged commits comprises only of numbers and dots
+            return gitversion
+        else:
+            # gitversion in commits that are not tagged has number of commits
+            # since the last tag and commit id attached to it.
+            # <tagname>-<ncommits-ahead>-<commit-id> (e.g. 0.2-8-adfebee)
+            build: List[str] = gitversion.split("-")
+            return "{}.post{}".format(build[0], build[1])
     except IndexError:
         cmd: List[str] = ["git", "rev-list", "--count", "HEAD"]
         commits_count: str = subprocess.check_output(

--- a/setup.py
+++ b/setup.py
@@ -29,14 +29,15 @@ def find_version(filename: str = "version") -> str:
         ).decode().strip()
         build: List[str] = gitversion.split("-")
         # <tagname>-<ncommits-ahead>-<commit-id> (e.g. 0.2-8-adfebee)
-        if len(build) > 1:
-            return "{}.post{}".format(build[0], build[1])
-
-        # tagged commit
-        return gitversion
+        return "{}.post{}".format(build[0], build[1])
+    except IndexError:
+        cmd: List[str] = ["git", "rev-list", "--count", "HEAD"]
+        commits_count: str = subprocess.check_output(
+            cmd, stderr=subprocess.DEVNULL
+        ).decode().strip()
+        return "0.0.dev{}".format(commits_count)
     except subprocess.CalledProcessError:
-        # If .git does not exist, default to an old dev version
-        return "0.1.dev0"
+        return "0.0.dev0"
 
 
 setup(version=find_version())


### PR DESCRIPTION
The problem was that `actions/checkout` was fetching only with depth 0, so only last commit was present in tests. Because of that the function `find_version` was returning short version of commit hash and this is no longer supported.