### PR TITLE
define snap architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,9 @@ description: |
   This CLI tool is a Juju plugin that allows user to check whether it's safe
   to perform some disruptive maintenance operations on Juju units, like `shutdown`
   or `reboot`.
-
+architectures:
+  - amd64
+  - arm64
 grade: stable
 confinement: strict
 


### PR DESCRIPTION
Right now snap is build for all architectures and we should support only `amd64` and `arm64`.