### PR TITLE
added build-on on architectures in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,8 +7,8 @@ description: |
   to perform some disruptive maintenance operations on Juju units, like `shutdown`
   or `reboot`.
 architectures:
-  - amd64
-  - arm64
+  - build-on: amd64
+  - build-on: arm64
 grade: stable
 confinement: strict
 


### PR DESCRIPTION
documentation of architectures[0] allows to use multiple architectures, shorthand (Example 4), but remote-build[1] uses explicitly "build-on" on architectures. Without it, the remote-build has strange behaviors.

[0] https://snapcraft.io/docs/architectures
[0] https://snapcraft.io/docs/remote-build